### PR TITLE
Reflect current branding for Anaconda - no more CE

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -48,7 +48,7 @@
     <h4>Python</h4>
     <ul>
       <li>
-        Download and install  <a href="http://continuum.io/anacondace.html">Anaconda CE</a>.
+        Download and install  <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
       </li>
       <li>
         Use all of the defaults for installation
@@ -129,7 +129,7 @@
     <h4>Python</h4>
     <ul>
       <li>
-        Download and install  <a href="http://continuum.io/anacondace.html">Anaconda CE</a>.
+        Download and install  <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
       </li>
       <li>
         Use all of the defaults for installation


### PR DESCRIPTION
Per http://continuum.io/blog/anaconda-1-4-released, and the redirect behavior at the old URL. Should help eliminate some confusion when students ask, "where's CE?"
